### PR TITLE
Track function identifier location in function info

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nuanced-dev/jellycg",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nuanced-dev/jellycg",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuanced-dev/jellycg",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Jelly - call graph and library usage analyzer for JavaScript",
   "author": "Anders Møller <amoeller@cs.au.dk>",
   "license": "MIT",

--- a/src/analysis/globalstate.ts
+++ b/src/analysis/globalstate.ts
@@ -239,7 +239,7 @@ export class GlobalState {
     registerFunctionInfo(file: FilePath, path: NodePath<Function>, name: string | undefined) {
         const fun = path.node;
         const m = this.moduleInfosByPath.get(file)!;
-        const f = new FunctionInfo(name, fun.loc!, m, isDummyConstructor(fun));
+        const f = new FunctionInfo(name, fun.loc!, "id" in fun ? fun.id?.loc! : undefined, m, isDummyConstructor(fun));
         this.functionInfos.set(fun, f);
         const parent = getEnclosingFunction(path);
         (parent ? this.functionInfos.get(parent)!.functions : m.functions).add(f);

--- a/src/analysis/infos.ts
+++ b/src/analysis/infos.ts
@@ -108,6 +108,7 @@ export class FunctionInfo {
     constructor(
         readonly name: string | undefined, // function name
         readonly loc: Location, // function source location
+        readonly idLoc: Location | undefined, // function identifier location
         readonly moduleInfo: ModuleInfo, // module containing this function
         readonly isDummyConstructor: boolean // true if dummy constructor
     ) {}


### PR DESCRIPTION
## Why

To allow interoperability with LSP we need to know the location of the identifier of function definitions, not just their full range.

## Changes

- Add optional `idLoc` field to `FunctionInfo`.
